### PR TITLE
COR:Correct global variable declaration

### DIFF
--- a/declaration.c
+++ b/declaration.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include "declaration.h"
+
+const int player1_turn = 1;
+const int player2_turn = 2;
+const int success = 1;
+const int failure = 0;
+
+Player_Info player1 = {'\0','\0'};
+Player_Info player2 = {'\0','\0'};

--- a/declaration.h
+++ b/declaration.h
@@ -7,12 +7,4 @@ typedef struct player_information
 	char name[11];
 }Player_Info;
 
-extern Player_Info player1;
-extern Player_Info player2;
-
-extern const int success;
-extern const int failure;
-extern const int player1_turn;
-extern const int player2_turn;
-
 #endif

--- a/gameboard.c
+++ b/gameboard.c
@@ -6,6 +6,12 @@
 #include "gamesetting.h"
 #pragma warning (disable:4996)
 
+extern const int player2_turn;
+extern const int success;
+extern const int failure;
+extern Player_Info player1;
+extern Player_Info player2;
+
 int checkHorizontal(char game_board[])
 {
 	if (isIndexValueSame(game_board, 0, 1, 2))

--- a/gamesetting.c
+++ b/gamesetting.c
@@ -4,6 +4,13 @@
 #include "gamesetting.h"
 #pragma warning (disable:4996)
 
+extern const int player1_turn;
+extern const int player2_turn;
+extern const int success;
+extern const int failure;
+extern Player_Info player1;
+extern Player_Info player2;
+
 char checkSymbol(int current_player) 
 {
 	if (current_player == player1_turn)

--- a/leaderboard.c
+++ b/leaderboard.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include "declaration.h"
 #include "leaderboard.h"
+#include "ui.h"
 #pragma warning (disable:4996)
 
 void showLeaderBoard(void)

--- a/main.c
+++ b/main.c
@@ -17,15 +17,9 @@ Author:- Mishal Shah
 #pragma warning (disable:4996)
 #define _CRT_SECURE_NO_WARNINGS
 
-const int player1_turn = 1;
-const int player2_turn = 2;
-const int success=1;
-const int failure=0;
-Player_Info player1 = {'\0','\0'};
-Player_Info player2 = { '\0','\0' };
-
 int main(void)
 {
-
 	startTicTacToe();
+	
+	return 0;
 }

--- a/playwithcomputer.c
+++ b/playwithcomputer.c
@@ -6,6 +6,10 @@
 #include "gamesetting.h"
 #pragma warning (disable:4996)
 
+extern const int player1_turn;
+extern Player_Info player1;
+extern Player_Info player2;
+
 int checkValueOnComputer(char game_board[], int index1, int index2, int index3, char symbol)
 {
 	if (game_board[index1] == symbol && game_board[index2] == symbol)

--- a/playwithfriend.c
+++ b/playwithfriend.c
@@ -6,6 +6,11 @@
 #include "gamesetting.h"
 #pragma warning (disable:4996)
 
+extern const int success;
+extern const int failure;
+extern Player_Info player1;
+extern Player_Info player2;
+
 void playWithFriend(void) 
 {
 	const int keepGoing = 0;


### PR DESCRIPTION
Create file 'declaration.c' to declare global variables.
Change the declaration loaction of 'player1_turn', 'player2_turn',
'success', 'failure', 'player1', 'player2' variables from 'main.c' to
'declaration.c'.
Remove the useless statements about the global variable in
"declaration.h".
